### PR TITLE
Fixed panic caused by rev check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -326,16 +326,13 @@ fn real_main(options: Args, config: &mut Config) -> CliResult {
 
     // if this is not a tag we need to include some data about the version in PV so that
     // the sstate cache remains valid
-    let git_srcpv = if project_repo.tag && project_repo.rev.len() > 10 {
-        // its a tag so nothing needed
-        "".into()
-    } else {
+    let git_srcpv = if !project_repo.tag && project_repo.rev.len() > 10 {
         // we should be using ${SRCPV} here but due to a bitbake bug we cannot. see:
         // https://github.com/meta-rust/meta-rust/issues/136
-        format!(
-            "PV_append = \".AUTOINC+{}\"",
-            project_repo.rev.split_at(10).0
-        )
+        format!("PV_append = \".AUTOINC+{}\"", &project_repo.rev[..10])
+    } else {
+        // its a tag so nothing needed
+        "".into()
     };
 
     // build up the path


### PR DESCRIPTION
This took some time to track down. I added a `.dockerignore` to the project I'm working on, which included `.git` and suddenly builds started failing. Tracked down that `cargo bitbake` started panicking, due to the missing repo.

Fixed the issue. The rev check was passing, if it wasn't a tag, regardless whether the rev string was +10 chars.
