### PR TITLE
recommend cargo install --locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ project for [Yocto](https://yoctoproject.org)
 Install it with Cargo:
 
 ```
-$ cargo install cargo-bitbake
+$ cargo install --locked cargo-bitbake
 ```
 
 In its default mode, `cargo bitbake` will write the recipe for the


### PR DESCRIPTION
This avoids issues with incompatible changes in the dependencies (such
as in #29).