### PR TITLE
Add support for selecting Cargo features

### DIFF
--- a/src/bitbake.template
+++ b/src/bitbake.template
@@ -13,6 +13,8 @@ S = "${{WORKDIR}}/git"
 CARGO_SRC_DIR = "{project_rel_dir}"
 {git_srcpv}
 
+{features}
+
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched
 SRC_URI += " \

--- a/src/git.rs
+++ b/src/git.rs
@@ -56,7 +56,7 @@ pub fn git_to_yocto_git_url(url: &str, name: Option<&str>, prefix: GitPrefix) ->
     // check if its a git@github.com:cardoe/cargo-bitbake.git style URL
     // and fix it up if it is
     let fixed_url = if SSH_STYLE_REMOTE.is_match(url) {
-        format!("ssh://{}", url.replace(":", "/"))
+        format!("ssh://{}", url.replace(':', "/"))
     } else {
         url.to_string()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ fn real_main(options: Args, config: &mut Config) -> CliResult {
             println!("No package.description set in your Cargo.toml, using package.name");
             package.name()
         },
-        |s| cargo::util::interning::InternedString::new(&s.trim().replace("\n", " \\\n")),
+        |s| cargo::util::interning::InternedString::new(&s.trim().replace('\n', " \\\n")),
     );
 
     // package homepage (or source code location)

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,16 @@ struct Args {
     /// Legacy Overrides: Use legacy override syntax
     #[structopt(short = "l", long = "--legacy-overrides")]
     legacy_overrides: bool,
+
+    /// Space or comma separated list of Cargo features to activate
+    #[structopt(long = "--features")]
+    features: Option<String>,
+    /// Activate all available Cargo features
+    #[structopt(long = "--all-features")]
+    all_features: bool,
+    /// Do not activate the Cargo `default` features
+    #[structopt(long = "--no-default-features")]
+    no_default_features: bool,
 }
 
 #[derive(StructOpt, Debug)]
@@ -401,6 +411,7 @@ fn real_main(options: Args, config: &mut Config) -> CliResult {
         project_src_uri = project_repo.uri,
         project_src_rev = project_repo.rev,
         git_srcpv = git_srcpv,
+        features = feature_variable_assignments(&options).join("\n"),
         cargo_bitbake_ver = env!("CARGO_PKG_VERSION"),
     )
     .map_err(|e| anyhow!("Unable to write to bitbake recipe file with: {}", e))?;
@@ -408,4 +419,30 @@ fn real_main(options: Args, config: &mut Config) -> CliResult {
     println!("Wrote: {}", recipe_path.display());
 
     Ok(())
+}
+
+/// Returns a vector of variable assignments for the feature selection given
+/// through `options`. This vector may come in handy for not generating many
+/// empty lines in the actual output in case that no feature selection is made
+/// at all.
+///
+/// # Arguments
+///
+/// * `options` - The program arguments with the current feature selection
+fn feature_variable_assignments(options: &Args) -> Vec<String> {
+    let mut output = Vec::new();
+
+    if let Some(features) = &options.features {
+        output.push(format!("CARGO_FEATURES = \"{}\"", features));
+    }
+
+    if options.all_features {
+        output.push(String::from("CARGO_ALL_FEATURES = \"1\""));
+    }
+
+    if options.no_default_features {
+        output.push(String::from("CARGO_NO_DEFAULT_FEATURES = \"1\""));
+    }
+
+    output
 }


### PR DESCRIPTION
- This is a companion to https://github.com/meta-rust/meta-rust/pull/382 adding feature selection support to `cargo-bitbake`
- Adds CLI arguments equivalent to the ones of Cargo for selecting or deselection features
    - `--features LIST`
    - `--all-features`
    - `--no-default-features`
- It depends on https://github.com/meta-rust/meta-rust/pull/382